### PR TITLE
fix: rename "assert" constant into "expect"

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Let's implement this scenario using Grinch.
 First, let's import neccessary members:
 
 ```typescript
-import { assert, scenario } from "grinch";
+import { expect, scenario } from "grinch";
 ```
 
 Now let's create a state for the senario:
@@ -132,7 +132,7 @@ export const PostCreationScenario = scenario("Create post", state, ({ test }) =>
 
             // getting JWT token from response and saving it to state
             const { jwt } = (await response.json()) as { jwt: string };
-            assert.string(jwt).toBeDefined();
+            expect.string(jwt).toBeDefined();
             state.jwt = jwt;
         });
 
@@ -149,11 +149,11 @@ export const PostCreationScenario = scenario("Create post", state, ({ test }) =>
                     Authorization: `Bearer ${state.jwt}`
                 }
             });
-            assert.number(response.status).toBe(200);
+            expect.number(response.status).toBe(200);
 
             // saving post id for further post getting
             const { id: postId } = (await response.json()) as { id: string };
-            assert.string(postId).toBeUUID();
+            expect.string(postId).toBeUUID();
             state.postId = postId;
         });
 
@@ -169,7 +169,7 @@ export const PostCreationScenario = scenario("Create post", state, ({ test }) =>
 
             // checking validity of new post
             const { id: postId } = (await response.json()) as { id: string };
-            assert.string(postId).toBe(state.postId as string);
+            expect.string(postId).toBe(state.postId as string);
         });
     });
 });
@@ -416,7 +416,7 @@ results.then(processResults);
 
 Grinch offers a number of built-in statements that have a chained interface.
 
-All statements are created using the `assert` object.
+All statements are created using the `expect` object.
 
 ### Basic Assertions
 
@@ -437,9 +437,9 @@ Basic assertion is a set of statements that are inherited by all other statement
 Usage:
 
 ```typescript
-import { assert } from "grinch";
+import { expect } from "grinch";
 
-assert
+expect
     .basic(1)
     .toBe(1)
     .toBeTruthy()
@@ -486,9 +486,9 @@ Number assertion also inherits the statements of the basic assertion.
 Usage:
 
 ```typescript
-import { assert } from "grinch";
+import { expect } from "grinch";
 
-assert
+expect
     .number(1)
     .toBePositive()
     .toBeLessThan(5)
@@ -517,9 +517,9 @@ String assertion also inherits the statements of the basic assertion and iterabl
 Usage:
 
 ```typescript
-import { assert } from "grinch";
+import { expect } from "grinch";
 
-assert
+expect
     .string("Alpha Centauri")
     .toStartsWith("Alpha")
     .toEndsWith("Centauri")
@@ -543,14 +543,14 @@ Record assertion also inherits the statements of the basic assertion.
 Usage:
 
 ```typescript
-import { assert } from "grinch";
+import { expect } from "grinch";
 
 const person = {
     name: "Julia",
     age: 42
 };
 
-assert
+expect
     .record(person)
     .toBeDefined() // statement from basic assertion
     .toHaveKey("name")
@@ -572,11 +572,11 @@ Array assertion also inherits the statements of the basic assertion and iterable
 Usage:
 
 ```typescript
-import { assert } from "grinch";
+import { expect } from "grinch";
 
 const numbers = [1, 2, 3, 4, 5];
 
-assert
+expect
     .array(numbers)
     .toBeDefined() // statement from basic assertion
     .toHaveLength(5) // statement from iterable assertion
@@ -604,10 +604,10 @@ Unknown assertion also inherits the statements of the basic assertion.
 Usage:
 
 ```typescript
-import { assert } from "grinch";
+import { expect } from "grinch";
 import { unknownValue } from "./data.ts";
 
-assert
+expect
     .unknown(unknownValue)
     .toBeDefined() // statement from basic assertion
     .toBeRecord();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { createScenario as scenario, mapScenarios } from "@modules/scenarios";
 export { createReusableTest as reusableTest, reuseTest } from "@modules/reusable-tests";
 export { type Results } from "@modules/testing-tree";
-export { assert } from "@modules/assertions";
+export { expect } from "@modules/assertions";

--- a/src/modules/assertions/index.ts
+++ b/src/modules/assertions/index.ts
@@ -2,4 +2,4 @@ import { AssertionFactory } from "./assertion-factory";
 
 export { AssertionError } from "./lib/errors";
 
-export const assert = new AssertionFactory();
+export const expect = new AssertionFactory();

--- a/tests/assertions/array/scenario.ts
+++ b/tests/assertions/array/scenario.ts
@@ -1,4 +1,4 @@
-import { assert, scenario } from "../../../src";
+import { expect, scenario } from "../../../src";
 import { arrayAssertionGenerators } from "./generators";
 
 export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }) => {
@@ -8,7 +8,7 @@ export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }
                 const values = arrayAssertionGenerators.toHaveLength.valid();
 
                 for (const { value, length } of values) {
-                    assert.array(value).toHaveLength(length);
+                    expect.array(value).toHaveLength(length);
                 }
             });
 
@@ -16,7 +16,7 @@ export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }
                 const values = arrayAssertionGenerators.toHaveLength.invalid();
 
                 for (const { value, length } of values) {
-                    assert.array(value).not.toHaveLength(length);
+                    expect.array(value).not.toHaveLength(length);
                 }
             });
         });
@@ -26,7 +26,7 @@ export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }
                 const values = arrayAssertionGenerators.toBeShorterThan.valid();
 
                 for (const { value, length } of values) {
-                    assert.array(value).toBeShorterThan(length);
+                    expect.array(value).toBeShorterThan(length);
                 }
             });
 
@@ -34,7 +34,7 @@ export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }
                 const values = arrayAssertionGenerators.toBeShorterThan.invalid();
 
                 for (const { value, length } of values) {
-                    assert.array(value).not.toBeShorterThan(length);
+                    expect.array(value).not.toBeShorterThan(length);
                 }
             });
         });
@@ -44,7 +44,7 @@ export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }
                 const values = arrayAssertionGenerators.toBeShorterThanOrEquals.valid();
 
                 for (const { value, length } of values) {
-                    assert.array(value).toBeShorterThanOrEquals(length);
+                    expect.array(value).toBeShorterThanOrEquals(length);
                 }
             });
 
@@ -52,7 +52,7 @@ export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }
                 const values = arrayAssertionGenerators.toBeShorterThanOrEquals.invalid();
 
                 for (const { value, length } of values) {
-                    assert.array(value).not.toBeShorterThanOrEquals(length);
+                    expect.array(value).not.toBeShorterThanOrEquals(length);
                 }
             });
         });
@@ -62,7 +62,7 @@ export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }
                 const values = arrayAssertionGenerators.toBeLongerThan.valid();
 
                 for (const { value, length } of values) {
-                    assert.array(value).not.toBeLongerThan(length);
+                    expect.array(value).not.toBeLongerThan(length);
                 }
             });
 
@@ -70,7 +70,7 @@ export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }
                 const values = arrayAssertionGenerators.toBeLongerThan.invalid();
 
                 for (const { value, length } of values) {
-                    assert.array(value).not.toBeLongerThan(length);
+                    expect.array(value).not.toBeLongerThan(length);
                 }
             });
         });
@@ -80,7 +80,7 @@ export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }
                 const values = arrayAssertionGenerators.toBeLongerThanOrEquals.valid();
 
                 for (const { value, length } of values) {
-                    assert.array(value).toBeLongerThanOrEquals(length);
+                    expect.array(value).toBeLongerThanOrEquals(length);
                 }
             });
 
@@ -88,7 +88,7 @@ export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }
                 const values = arrayAssertionGenerators.toBeLongerThanOrEquals.invalid();
 
                 for (const { value, length } of values) {
-                    assert.array(value).not.toBeLongerThanOrEquals(length);
+                    expect.array(value).not.toBeLongerThanOrEquals(length);
                 }
             });
         });
@@ -98,7 +98,7 @@ export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }
                 const values = arrayAssertionGenerators.toHaveLengthBetween.valid();
 
                 for (const { value, start, end } of values) {
-                    assert.array(value).toHaveLengthBetween(start, end);
+                    expect.array(value).toHaveLengthBetween(start, end);
                 }
             });
 
@@ -106,7 +106,7 @@ export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }
                 const values = arrayAssertionGenerators.toHaveLengthBetween.invalid();
 
                 for (const { value, start, end } of values) {
-                    assert.array(value).not.toHaveLengthBetween(start, end);
+                    expect.array(value).not.toHaveLengthBetween(start, end);
                 }
             });
         });
@@ -116,7 +116,7 @@ export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }
                 const values = arrayAssertionGenerators.toIncludes.valid();
 
                 for (const { value, item } of values) {
-                    assert.array(value).not.toIncludes(item);
+                    expect.array(value).not.toIncludes(item);
                 }
             });
 
@@ -124,7 +124,7 @@ export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }
                 const values = arrayAssertionGenerators.toIncludes.invalid();
 
                 for (const { value, item } of values) {
-                    assert.array(value).not.toIncludes(item);
+                    expect.array(value).not.toIncludes(item);
                 }
             });
         });
@@ -134,7 +134,7 @@ export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }
                 const values = arrayAssertionGenerators.toHaveValueAtIndex.valid();
 
                 for (const { value, index, item } of values) {
-                    assert.array(value).not.toHaveValueAtIndex(index, item);
+                    expect.array(value).not.toHaveValueAtIndex(index, item);
                 }
             });
 
@@ -142,7 +142,7 @@ export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }
                 const values = arrayAssertionGenerators.toHaveValueAtIndex.invalid();
 
                 for (const { value, index, item } of values) {
-                    assert.array(value).not.toHaveValueAtIndex(index, item);
+                    expect.array(value).not.toHaveValueAtIndex(index, item);
                 }
             });
         });
@@ -152,7 +152,7 @@ export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }
                 const values = arrayAssertionGenerators.toHaveSomeMatch.valid();
 
                 for (const { value, condition } of values) {
-                    assert.array(value).toHaveSomeMatch(condition);
+                    expect.array(value).toHaveSomeMatch(condition);
                 }
             });
 
@@ -160,7 +160,7 @@ export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }
                 const values = arrayAssertionGenerators.toHaveSomeMatch.invalid();
 
                 for (const { value, condition } of values) {
-                    assert.array(value).not.toHaveSomeMatch(condition);
+                    expect.array(value).not.toHaveSomeMatch(condition);
                 }
             });
         });
@@ -170,7 +170,7 @@ export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }
                 const values = arrayAssertionGenerators.toHaveEveryMatch.valid();
 
                 for (const { value, condition } of values) {
-                    assert.array(value).toHaveEveryMatch(condition);
+                    expect.array(value).toHaveEveryMatch(condition);
                 }
             });
 
@@ -178,7 +178,7 @@ export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }
                 const values = arrayAssertionGenerators.toHaveEveryMatch.invalid();
 
                 for (const { value, condition } of values) {
-                    assert.array(value).not.toHaveEveryMatch(condition);
+                    expect.array(value).not.toHaveEveryMatch(condition);
                 }
             });
         });
@@ -188,7 +188,7 @@ export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }
                 const values = arrayAssertionGenerators.toBeSorted.valid();
 
                 for (const { value, comparator } of values) {
-                    assert.array(value).toBeSorted(comparator);
+                    expect.array(value).toBeSorted(comparator);
                 }
             });
 
@@ -196,7 +196,7 @@ export const ArrayAssertionScenario = scenario("ArrayAssertion", null, ({ test }
                 const values = arrayAssertionGenerators.toBeSorted.invalid();
 
                 for (const { value, comparator } of values) {
-                    assert.array(value).not.toBeSorted(comparator);
+                    expect.array(value).not.toBeSorted(comparator);
                 }
             });
         });

--- a/tests/assertions/basic/scenario.ts
+++ b/tests/assertions/basic/scenario.ts
@@ -1,4 +1,4 @@
-import { assert, scenario } from "../../../src";
+import { expect, scenario } from "../../../src";
 import { basicAssertionGenerators } from "./generators";
 
 export const BasicAssertionScenario = scenario("Basic Assertions", null, ({ test }) => {
@@ -8,7 +8,7 @@ export const BasicAssertionScenario = scenario("Basic Assertions", null, ({ test
                 const values = basicAssertionGenerators.toBe.valid();
 
                 for (const value of values) {
-                    assert.basic(value).toBe(value);
+                    expect.basic(value).toBe(value);
                 }
             });
 
@@ -16,7 +16,7 @@ export const BasicAssertionScenario = scenario("Basic Assertions", null, ({ test
                 const values = basicAssertionGenerators.toBe.invalid();
 
                 for (const value of values) {
-                    assert.basic(value.value1).not.toBe(value.value2);
+                    expect.basic(value.value1).not.toBe(value.value2);
                 }
             });
         });
@@ -26,7 +26,7 @@ export const BasicAssertionScenario = scenario("Basic Assertions", null, ({ test
                 const values = basicAssertionGenerators.toBeDefined.valid();
 
                 for (const value of values) {
-                    assert.basic(value).toBeDefined();
+                    expect.basic(value).toBeDefined();
                 }
             });
 
@@ -34,7 +34,7 @@ export const BasicAssertionScenario = scenario("Basic Assertions", null, ({ test
                 const values = basicAssertionGenerators.toBeDefined.invalid();
 
                 for (const value of values) {
-                    assert.basic(value).not.toBeDefined();
+                    expect.basic(value).not.toBeDefined();
                 }
             });
         });
@@ -44,7 +44,7 @@ export const BasicAssertionScenario = scenario("Basic Assertions", null, ({ test
                 const values = basicAssertionGenerators.toBeNull.valid();
 
                 for (const value of values) {
-                    assert.basic(value).toBeNull();
+                    expect.basic(value).toBeNull();
                 }
             });
 
@@ -52,7 +52,7 @@ export const BasicAssertionScenario = scenario("Basic Assertions", null, ({ test
                 const values = basicAssertionGenerators.toBeNull.invalid();
 
                 for (const value of values) {
-                    assert.basic(value).not.toBeNull();
+                    expect.basic(value).not.toBeNull();
                 }
             });
         });
@@ -62,7 +62,7 @@ export const BasicAssertionScenario = scenario("Basic Assertions", null, ({ test
                 const values = basicAssertionGenerators.toBeEmpty.valid();
 
                 for (const value of values) {
-                    assert.basic(value).toBeEmpty();
+                    expect.basic(value).toBeEmpty();
                 }
             });
 
@@ -70,7 +70,7 @@ export const BasicAssertionScenario = scenario("Basic Assertions", null, ({ test
                 const values = basicAssertionGenerators.toBeEmpty.invalid();
 
                 for (const value of values) {
-                    assert.basic(value).not.toBeEmpty();
+                    expect.basic(value).not.toBeEmpty();
                 }
             });
         });
@@ -80,7 +80,7 @@ export const BasicAssertionScenario = scenario("Basic Assertions", null, ({ test
                 const values = basicAssertionGenerators.toBeTruthy.valid();
 
                 for (const value of values) {
-                    assert.basic(value).toBeTruthy();
+                    expect.basic(value).toBeTruthy();
                 }
             });
 
@@ -88,7 +88,7 @@ export const BasicAssertionScenario = scenario("Basic Assertions", null, ({ test
                 const values = basicAssertionGenerators.toBeTruthy.invalid();
 
                 for (const value of values) {
-                    assert.basic(value).not.toBeTruthy();
+                    expect.basic(value).not.toBeTruthy();
                 }
             });
         });
@@ -98,7 +98,7 @@ export const BasicAssertionScenario = scenario("Basic Assertions", null, ({ test
                 const values = basicAssertionGenerators.toBeFalsy.valid();
 
                 for (const value of values) {
-                    assert.basic(value).toBeFalsy();
+                    expect.basic(value).toBeFalsy();
                 }
             });
 
@@ -106,7 +106,7 @@ export const BasicAssertionScenario = scenario("Basic Assertions", null, ({ test
                 const values = basicAssertionGenerators.toBeFalsy.invalid();
 
                 for (const value of values) {
-                    assert.basic(value).not.toBeFalsy();
+                    expect.basic(value).not.toBeFalsy();
                 }
             });
         });
@@ -116,7 +116,7 @@ export const BasicAssertionScenario = scenario("Basic Assertions", null, ({ test
                 const values = basicAssertionGenerators.toBeNull.valid();
 
                 for (const value of values) {
-                    assert.basic(value).toBeNull();
+                    expect.basic(value).toBeNull();
                 }
             });
 
@@ -124,7 +124,7 @@ export const BasicAssertionScenario = scenario("Basic Assertions", null, ({ test
                 const values = basicAssertionGenerators.toBeNull.valid();
 
                 for (const value of values) {
-                    assert.basic(value).not.toBeNull();
+                    expect.basic(value).not.toBeNull();
                 }
             });
         });
@@ -134,7 +134,7 @@ export const BasicAssertionScenario = scenario("Basic Assertions", null, ({ test
                 const values = basicAssertionGenerators.toMatchZodSchema.valid();
 
                 for (const { value, schema } of values) {
-                    assert.basic(value).toMatchZodSchema(schema);
+                    expect.basic(value).toMatchZodSchema(schema);
                 }
             });
 
@@ -142,7 +142,7 @@ export const BasicAssertionScenario = scenario("Basic Assertions", null, ({ test
                 const values = basicAssertionGenerators.toMatchZodSchema.invalid();
 
                 for (const { value, schema } of values) {
-                    assert.basic(value).not.toMatchZodSchema(schema);
+                    expect.basic(value).not.toMatchZodSchema(schema);
                 }
             });
         });
@@ -152,7 +152,7 @@ export const BasicAssertionScenario = scenario("Basic Assertions", null, ({ test
                 const values = basicAssertionGenerators.toSatisfy.valid();
 
                 for (const { value, condition } of values) {
-                    assert.basic(value).toSatisfy(condition);
+                    expect.basic(value).toSatisfy(condition);
                 }
             });
 
@@ -160,7 +160,7 @@ export const BasicAssertionScenario = scenario("Basic Assertions", null, ({ test
                 const values = basicAssertionGenerators.toSatisfy.invalid();
 
                 for (const { value, condition } of values) {
-                    assert.basic(value).not.toSatisfy(condition);
+                    expect.basic(value).not.toSatisfy(condition);
                 }
             });
         });

--- a/tests/assertions/number/scenario.ts
+++ b/tests/assertions/number/scenario.ts
@@ -1,4 +1,4 @@
-import { assert, scenario } from "../../../src";
+import { expect, scenario } from "../../../src";
 import { numberAssertionGenertors } from "./generators";
 
 export const NumberAssertionScenario = scenario("NumberAssertion", null, ({ test }) => {
@@ -8,7 +8,7 @@ export const NumberAssertionScenario = scenario("NumberAssertion", null, ({ test
                 const values = numberAssertionGenertors.toBePositive.valid();
 
                 for (const value of values) {
-                    assert.number(value).toBePositive();
+                    expect.number(value).toBePositive();
                 }
             });
 
@@ -16,7 +16,7 @@ export const NumberAssertionScenario = scenario("NumberAssertion", null, ({ test
                 const values = numberAssertionGenertors.toBePositive.invalid();
 
                 for (const value of values) {
-                    assert.number(value).not.toBePositive();
+                    expect.number(value).not.toBePositive();
                 }
             });
         });
@@ -26,7 +26,7 @@ export const NumberAssertionScenario = scenario("NumberAssertion", null, ({ test
                 const values = numberAssertionGenertors.toBeNegative.valid();
 
                 for (const value of values) {
-                    assert.number(value).toBeNegative();
+                    expect.number(value).toBeNegative();
                 }
             });
 
@@ -34,7 +34,7 @@ export const NumberAssertionScenario = scenario("NumberAssertion", null, ({ test
                 const values = numberAssertionGenertors.toBeNegative.invalid();
 
                 for (const value of values) {
-                    assert.number(value).not.toBeNegative();
+                    expect.number(value).not.toBeNegative();
                 }
             });
         });
@@ -44,7 +44,7 @@ export const NumberAssertionScenario = scenario("NumberAssertion", null, ({ test
                 const values = numberAssertionGenertors.toBeInteger.valid();
 
                 for (const value of values) {
-                    assert.number(value).toBeInteger();
+                    expect.number(value).toBeInteger();
                 }
             });
 
@@ -52,7 +52,7 @@ export const NumberAssertionScenario = scenario("NumberAssertion", null, ({ test
                 const values = numberAssertionGenertors.toBeInteger.invalid();
 
                 for (const value of values) {
-                    assert.number(value).not.toBeInteger();
+                    expect.number(value).not.toBeInteger();
                 }
             });
         });
@@ -62,7 +62,7 @@ export const NumberAssertionScenario = scenario("NumberAssertion", null, ({ test
                 const values = numberAssertionGenertors.toBeFloat.valid();
 
                 for (const value of values) {
-                    assert.number(value).toBeFloat();
+                    expect.number(value).toBeFloat();
                 }
             });
 
@@ -70,7 +70,7 @@ export const NumberAssertionScenario = scenario("NumberAssertion", null, ({ test
                 const values = numberAssertionGenertors.toBeFloat.invalid();
 
                 for (const value of values) {
-                    assert.number(value).not.toBeFloat();
+                    expect.number(value).not.toBeFloat();
                 }
             });
         });
@@ -80,7 +80,7 @@ export const NumberAssertionScenario = scenario("NumberAssertion", null, ({ test
                 const values = numberAssertionGenertors.toBeNaN.valid();
 
                 for (const value of values) {
-                    assert.number(value).toBeNaN();
+                    expect.number(value).toBeNaN();
                 }
             });
 
@@ -88,7 +88,7 @@ export const NumberAssertionScenario = scenario("NumberAssertion", null, ({ test
                 const values = numberAssertionGenertors.toBeNaN.invalid();
 
                 for (const value of values) {
-                    assert.number(value).not.toBeNaN();
+                    expect.number(value).not.toBeNaN();
                 }
             });
         });
@@ -98,7 +98,7 @@ export const NumberAssertionScenario = scenario("NumberAssertion", null, ({ test
                 const values = numberAssertionGenertors.toBeLessThan.valid();
 
                 for (const value of values) {
-                    assert.number(value.value).toBeLessThan(value.argument);
+                    expect.number(value.value).toBeLessThan(value.argument);
                 }
             });
 
@@ -106,7 +106,7 @@ export const NumberAssertionScenario = scenario("NumberAssertion", null, ({ test
                 const values = numberAssertionGenertors.toBeLessThan.invalid();
 
                 for (const value of values) {
-                    assert.number(value.value).not.toBeLessThan(value.argument);
+                    expect.number(value.value).not.toBeLessThan(value.argument);
                 }
             });
         });
@@ -116,7 +116,7 @@ export const NumberAssertionScenario = scenario("NumberAssertion", null, ({ test
                 const values = numberAssertionGenertors.toBeLessThanOrEquals.valid();
 
                 for (const value of values) {
-                    assert.number(value.value).toBeLessThanOrEquals(value.argument);
+                    expect.number(value.value).toBeLessThanOrEquals(value.argument);
                 }
             });
 
@@ -124,7 +124,7 @@ export const NumberAssertionScenario = scenario("NumberAssertion", null, ({ test
                 const values = numberAssertionGenertors.toBeLessThanOrEquals.invalid();
 
                 for (const value of values) {
-                    assert.number(value.value).not.toBeLessThanOrEquals(value.argument);
+                    expect.number(value.value).not.toBeLessThanOrEquals(value.argument);
                 }
             });
         });
@@ -134,7 +134,7 @@ export const NumberAssertionScenario = scenario("NumberAssertion", null, ({ test
                 const values = numberAssertionGenertors.toBeGraterThan.valid();
 
                 for (const value of values) {
-                    assert.number(value.value).toBeGraterThan(value.argument);
+                    expect.number(value.value).toBeGraterThan(value.argument);
                 }
             });
 
@@ -142,7 +142,7 @@ export const NumberAssertionScenario = scenario("NumberAssertion", null, ({ test
                 const values = numberAssertionGenertors.toBeGraterThan.invalid();
 
                 for (const value of values) {
-                    assert.number(value.value).not.toBeGraterThan(value.argument);
+                    expect.number(value.value).not.toBeGraterThan(value.argument);
                 }
             });
         });
@@ -152,7 +152,7 @@ export const NumberAssertionScenario = scenario("NumberAssertion", null, ({ test
                 const values = numberAssertionGenertors.toBeGraterThanOrEquals.valid();
 
                 for (const value of values) {
-                    assert.number(value.value).toBeGraterThanOrEquals(value.argument);
+                    expect.number(value.value).toBeGraterThanOrEquals(value.argument);
                 }
             });
 
@@ -160,7 +160,7 @@ export const NumberAssertionScenario = scenario("NumberAssertion", null, ({ test
                 const values = numberAssertionGenertors.toBeGraterThanOrEquals.invalid();
 
                 for (const value of values) {
-                    assert.number(value.value).not.toBeGraterThanOrEquals(value.argument);
+                    expect.number(value.value).not.toBeGraterThanOrEquals(value.argument);
                 }
             });
         });
@@ -170,7 +170,7 @@ export const NumberAssertionScenario = scenario("NumberAssertion", null, ({ test
                 const values = numberAssertionGenertors.toHaveValueBetween.valid();
 
                 for (const { value, start, end } of values) {
-                    assert.number(value).toHaveValueBetween(start, end);
+                    expect.number(value).toHaveValueBetween(start, end);
                 }
             });
 
@@ -178,7 +178,7 @@ export const NumberAssertionScenario = scenario("NumberAssertion", null, ({ test
                 const values = numberAssertionGenertors.toHaveValueBetween.invalid();
 
                 for (const { value, start, end } of values) {
-                    assert.number(value).not.toHaveValueBetween(start, end);
+                    expect.number(value).not.toHaveValueBetween(start, end);
                 }
             });
         });

--- a/tests/assertions/record/scenario.ts
+++ b/tests/assertions/record/scenario.ts
@@ -1,4 +1,4 @@
-import { assert, scenario } from "../../../src";
+import { expect, scenario } from "../../../src";
 import { recordAssertionGenerators } from "./generators";
 
 export const RecordAssertionScenario = scenario("RecordAssertion", null, ({ test }) => {
@@ -8,7 +8,7 @@ export const RecordAssertionScenario = scenario("RecordAssertion", null, ({ test
                 const values = recordAssertionGenerators.toEquals.valid();
 
                 for (const value of values) {
-                    assert.record(value).toEquals(value);
+                    expect.record(value).toEquals(value);
                 }
             });
 
@@ -16,7 +16,7 @@ export const RecordAssertionScenario = scenario("RecordAssertion", null, ({ test
                 const values = recordAssertionGenerators.toEquals.invalid();
 
                 for (const value of values) {
-                    assert.record(value).not.toEquals(value);
+                    expect.record(value).not.toEquals(value);
                 }
             });
         });
@@ -26,7 +26,7 @@ export const RecordAssertionScenario = scenario("RecordAssertion", null, ({ test
                 const values = recordAssertionGenerators.toHaveKey.valid();
 
                 for (const { value, key } of values) {
-                    assert.record(value).toHaveKey(key);
+                    expect.record(value).toHaveKey(key);
                 }
             });
 
@@ -34,7 +34,7 @@ export const RecordAssertionScenario = scenario("RecordAssertion", null, ({ test
                 const values = recordAssertionGenerators.toHaveKey.invalid();
 
                 for (const { value, key } of values) {
-                    assert.record(value).not.toHaveKey(key);
+                    expect.record(value).not.toHaveKey(key);
                 }
             });
         });
@@ -44,7 +44,7 @@ export const RecordAssertionScenario = scenario("RecordAssertion", null, ({ test
                 const values = recordAssertionGenerators.toHaveAllKeys.valid();
 
                 for (const { value, keys } of values) {
-                    assert.record(value).toHaveAllKeys(keys);
+                    expect.record(value).toHaveAllKeys(keys);
                 }
             });
 
@@ -52,7 +52,7 @@ export const RecordAssertionScenario = scenario("RecordAssertion", null, ({ test
                 const values = recordAssertionGenerators.toHaveAllKeys.invalid();
 
                 for (const { value, keys } of values) {
-                    assert.record(value).not.toHaveAllKeys(keys);
+                    expect.record(value).not.toHaveAllKeys(keys);
                 }
             });
         });
@@ -63,7 +63,7 @@ export const RecordAssertionScenario = scenario("RecordAssertion", null, ({ test
 
                 for (const { value, keys } of values) {
                     for (const key of keys) {
-                        assert.record(value).toHaveKeyWithValue(key, value[key]);
+                        expect.record(value).toHaveKeyWithValue(key, value[key]);
                     }
                 }
             });
@@ -73,7 +73,7 @@ export const RecordAssertionScenario = scenario("RecordAssertion", null, ({ test
 
                 for (const { record, keys } of values) {
                     for (const { key, value } of keys) {
-                        assert.record(record).not.toHaveKeyWithValue(key, value);
+                        expect.record(record).not.toHaveKeyWithValue(key, value);
                     }
                 }
             });

--- a/tests/assertions/string/scenario.ts
+++ b/tests/assertions/string/scenario.ts
@@ -1,4 +1,4 @@
-import { assert, scenario } from "../../../src";
+import { expect, scenario } from "../../../src";
 import { stringAssertionGenerators } from "./generators";
 
 export const StringAssertionScenario = scenario("StringAssertion", null, ({ test }) => {
@@ -8,7 +8,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toBeUpperCase.valid();
 
                 for (const value of values) {
-                    assert.string(value).toBeUpperCase();
+                    expect.string(value).toBeUpperCase();
                 }
             });
 
@@ -16,7 +16,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toBeUpperCase.invalid();
 
                 for (const value of values) {
-                    assert.string(value).not.toBeUpperCase();
+                    expect.string(value).not.toBeUpperCase();
                 }
             });
         });
@@ -26,7 +26,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toBeLowerCase.valid();
 
                 for (const value of values) {
-                    assert.string(value).toBeLowerCase();
+                    expect.string(value).toBeLowerCase();
                 }
             });
 
@@ -34,7 +34,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toBeLowerCase.invalid();
 
                 for (const value of values) {
-                    assert.string(value).not.toBeLowerCase();
+                    expect.string(value).not.toBeLowerCase();
                 }
             });
         });
@@ -44,7 +44,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toStartsWith.valid();
 
                 for (const { value, substr } of values) {
-                    assert.string(value).toStartsWith(substr);
+                    expect.string(value).toStartsWith(substr);
                 }
             });
 
@@ -52,7 +52,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toStartsWith.invalid();
 
                 for (const { value, substr } of values) {
-                    assert.string(value).not.toStartsWith(substr);
+                    expect.string(value).not.toStartsWith(substr);
                 }
             });
         });
@@ -62,7 +62,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toEndsWith.valid();
 
                 for (const { value, substr } of values) {
-                    assert.string(value).toEndsWith(substr);
+                    expect.string(value).toEndsWith(substr);
                 }
             });
 
@@ -70,7 +70,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toEndsWith.invalid();
 
                 for (const { value, substr } of values) {
-                    assert.string(value).not.toEndsWith(substr);
+                    expect.string(value).not.toEndsWith(substr);
                 }
             });
         });
@@ -80,7 +80,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toBeNumericString.valid();
 
                 for (const value of values) {
-                    assert.string(value).toBeNumericString();
+                    expect.string(value).toBeNumericString();
                 }
             });
 
@@ -88,7 +88,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toBeNumericString.invalid();
 
                 for (const value of values) {
-                    assert.string(value).not.toBeNumericString();
+                    expect.string(value).not.toBeNumericString();
                 }
             });
         });
@@ -98,7 +98,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toBeBooleanString.valid();
 
                 for (const value of values) {
-                    assert.string(value).toBeBooleanString();
+                    expect.string(value).toBeBooleanString();
                 }
             });
 
@@ -106,7 +106,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toBeBooleanString.invalid();
 
                 for (const value of values) {
-                    assert.string(value).not.toBeBooleanString();
+                    expect.string(value).not.toBeBooleanString();
                 }
             });
         });
@@ -116,7 +116,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toMatchRegex.valid();
 
                 for (const { value, regexp } of values) {
-                    assert.string(value).toMatchRegex(regexp);
+                    expect.string(value).toMatchRegex(regexp);
                 }
             });
 
@@ -124,7 +124,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toMatchRegex.invalid();
 
                 for (const { value, regexp } of values) {
-                    assert.string(value).not.toMatchRegex(regexp);
+                    expect.string(value).not.toMatchRegex(regexp);
                 }
             });
         });
@@ -134,7 +134,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toBeUUID.valid();
 
                 for (const value of values) {
-                    assert.string(value).toBeUUID();
+                    expect.string(value).toBeUUID();
                 }
             });
 
@@ -142,7 +142,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toBeUUID.invalid();
 
                 for (const value of values) {
-                    assert.string(value).not.toBeUUID();
+                    expect.string(value).not.toBeUUID();
                 }
             });
         });
@@ -152,7 +152,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toHaveLength.valid();
 
                 for (const { value, length } of values) {
-                    assert.string(value).toHaveLength(length);
+                    expect.string(value).toHaveLength(length);
                 }
             });
 
@@ -160,7 +160,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toHaveLength.invalid();
 
                 for (const { value, length } of values) {
-                    assert.string(value).not.toHaveLength(length);
+                    expect.string(value).not.toHaveLength(length);
                 }
             });
         });
@@ -170,7 +170,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toBeShorterThan.valid();
 
                 for (const { value, length } of values) {
-                    assert.string(value).toBeShorterThan(length);
+                    expect.string(value).toBeShorterThan(length);
                 }
             });
 
@@ -178,7 +178,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toBeShorterThan.invalid();
 
                 for (const { value, length } of values) {
-                    assert.string(value).not.toBeShorterThan(length);
+                    expect.string(value).not.toBeShorterThan(length);
                 }
             });
         });
@@ -188,7 +188,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toBeShorterThanOrEquals.valid();
 
                 for (const { value, length } of values) {
-                    assert.string(value).toBeShorterThanOrEquals(length);
+                    expect.string(value).toBeShorterThanOrEquals(length);
                 }
             });
 
@@ -196,7 +196,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toBeShorterThanOrEquals.invalid();
 
                 for (const { value, length } of values) {
-                    assert.string(value).not.toBeShorterThanOrEquals(length);
+                    expect.string(value).not.toBeShorterThanOrEquals(length);
                 }
             });
         });
@@ -206,7 +206,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toBeLongerThan.valid();
 
                 for (const { value, length } of values) {
-                    assert.string(value).toBeLongerThan(length);
+                    expect.string(value).toBeLongerThan(length);
                 }
             });
 
@@ -214,7 +214,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toBeLongerThan.invalid();
 
                 for (const { value, length } of values) {
-                    assert.string(value).not.toBeLongerThan(length);
+                    expect.string(value).not.toBeLongerThan(length);
                 }
             });
         });
@@ -224,7 +224,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toBeLongerThanOrEquals.valid();
 
                 for (const { value, length } of values) {
-                    assert.string(value).toBeLongerThanOrEquals(length);
+                    expect.string(value).toBeLongerThanOrEquals(length);
                 }
             });
 
@@ -232,7 +232,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toBeLongerThanOrEquals.invalid();
 
                 for (const { value, length } of values) {
-                    assert.string(value).not.toBeLongerThanOrEquals(length);
+                    expect.string(value).not.toBeLongerThanOrEquals(length);
                 }
             });
         });
@@ -242,7 +242,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toHaveLengthBetween.valid();
 
                 for (const { value, start, end } of values) {
-                    assert.string(value).toHaveLengthBetween(start, end);
+                    expect.string(value).toHaveLengthBetween(start, end);
                 }
             });
 
@@ -250,7 +250,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toHaveLengthBetween.invalid();
 
                 for (const { value, start, end } of values) {
-                    assert.string(value).not.toHaveLengthBetween(start, end);
+                    expect.string(value).not.toHaveLengthBetween(start, end);
                 }
             });
         });
@@ -260,7 +260,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toIncludes.valid();
 
                 for (const { value, substr } of values) {
-                    assert.string(value).toIncludes(substr);
+                    expect.string(value).toIncludes(substr);
                 }
             });
 
@@ -268,7 +268,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toIncludes.invalid();
 
                 for (const { value, substr } of values) {
-                    assert.string(value).not.toIncludes(substr);
+                    expect.string(value).not.toIncludes(substr);
                 }
             });
         });
@@ -278,7 +278,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toHaveValueAtIndex.valid();
 
                 for (const { value, index, item } of values) {
-                    assert.string(value).toHaveValueAtIndex(index, item);
+                    expect.string(value).toHaveValueAtIndex(index, item);
                 }
             });
 
@@ -286,7 +286,7 @@ export const StringAssertionScenario = scenario("StringAssertion", null, ({ test
                 const values = stringAssertionGenerators.toHaveValueAtIndex.invalid();
 
                 for (const { value, index, item } of values) {
-                    assert.string(value).not.toHaveValueAtIndex(index, item);
+                    expect.string(value).not.toHaveValueAtIndex(index, item);
                 }
             });
         });

--- a/tests/assertions/unknown/scenario.ts
+++ b/tests/assertions/unknown/scenario.ts
@@ -1,4 +1,4 @@
-import { assert, scenario } from "../../../src";
+import { expect, scenario } from "../../../src";
 import { unknownAssertionGenerators } from "./generators";
 
 export const UnknownAssertionScenario = scenario("UnknownAssertion", null, ({ test }) => {
@@ -8,7 +8,7 @@ export const UnknownAssertionScenario = scenario("UnknownAssertion", null, ({ te
                 const values = unknownAssertionGenerators.toEquals.valid();
 
                 for (const value of values) {
-                    assert.unknown(value).toEquals(value);
+                    expect.unknown(value).toEquals(value);
                 }
             });
 
@@ -16,7 +16,7 @@ export const UnknownAssertionScenario = scenario("UnknownAssertion", null, ({ te
                 const values = unknownAssertionGenerators.toEquals.invalid();
 
                 for (const value of values) {
-                    assert.unknown(value).not.toEquals(value);
+                    expect.unknown(value).not.toEquals(value);
                 }
             });
         });
@@ -26,7 +26,7 @@ export const UnknownAssertionScenario = scenario("UnknownAssertion", null, ({ te
                 const values = unknownAssertionGenerators.toBeString.valid();
 
                 for (const value of values) {
-                    assert.unknown(value).toBeString();
+                    expect.unknown(value).toBeString();
                 }
             });
 
@@ -34,7 +34,7 @@ export const UnknownAssertionScenario = scenario("UnknownAssertion", null, ({ te
                 const values = unknownAssertionGenerators.toBeString.invalid();
 
                 for (const value of values) {
-                    assert.unknown(value).not.toBeString();
+                    expect.unknown(value).not.toBeString();
                 }
             });
         });
@@ -44,7 +44,7 @@ export const UnknownAssertionScenario = scenario("UnknownAssertion", null, ({ te
                 const values = unknownAssertionGenerators.toBeNumber.valid();
 
                 for (const value of values) {
-                    assert.unknown(value).toBeNumber();
+                    expect.unknown(value).toBeNumber();
                 }
             });
 
@@ -52,7 +52,7 @@ export const UnknownAssertionScenario = scenario("UnknownAssertion", null, ({ te
                 const values = unknownAssertionGenerators.toBeNumber.invalid();
 
                 for (const value of values) {
-                    assert.unknown(value).not.toBeNumber();
+                    expect.unknown(value).not.toBeNumber();
                 }
             });
         });
@@ -62,7 +62,7 @@ export const UnknownAssertionScenario = scenario("UnknownAssertion", null, ({ te
                 const values = unknownAssertionGenerators.toBeNaN.valid();
 
                 for (const value of values) {
-                    assert.unknown(value).toBeNaN();
+                    expect.unknown(value).toBeNaN();
                 }
             });
 
@@ -70,7 +70,7 @@ export const UnknownAssertionScenario = scenario("UnknownAssertion", null, ({ te
                 const values = unknownAssertionGenerators.toBeNaN.invalid();
 
                 for (const value of values) {
-                    assert.unknown(value).not.toBeNaN();
+                    expect.unknown(value).not.toBeNaN();
                 }
             });
         });
@@ -80,7 +80,7 @@ export const UnknownAssertionScenario = scenario("UnknownAssertion", null, ({ te
                 const values = unknownAssertionGenerators.toBeBoolean.valid();
 
                 for (const value of values) {
-                    assert.unknown(value).toBeBoolean();
+                    expect.unknown(value).toBeBoolean();
                 }
             });
 
@@ -88,7 +88,7 @@ export const UnknownAssertionScenario = scenario("UnknownAssertion", null, ({ te
                 const values = unknownAssertionGenerators.toBeBoolean.invalid();
 
                 for (const value of values) {
-                    assert.unknown(value).not.toBeBoolean();
+                    expect.unknown(value).not.toBeBoolean();
                 }
             });
         });
@@ -98,7 +98,7 @@ export const UnknownAssertionScenario = scenario("UnknownAssertion", null, ({ te
                 const values = unknownAssertionGenerators.toBeRecord.valid();
 
                 for (const value of values) {
-                    assert.unknown(value).toBeRecord();
+                    expect.unknown(value).toBeRecord();
                 }
             });
 
@@ -106,7 +106,7 @@ export const UnknownAssertionScenario = scenario("UnknownAssertion", null, ({ te
                 const values = unknownAssertionGenerators.toBeRecord.invalid();
 
                 for (const value of values) {
-                    assert.unknown(value).not.toBeRecord();
+                    expect.unknown(value).not.toBeRecord();
                 }
             });
         });
@@ -116,7 +116,7 @@ export const UnknownAssertionScenario = scenario("UnknownAssertion", null, ({ te
                 const values = unknownAssertionGenerators.toBeObject.valid();
 
                 for (const value of values) {
-                    assert.unknown(value).toBeObject();
+                    expect.unknown(value).toBeObject();
                 }
             });
 
@@ -124,7 +124,7 @@ export const UnknownAssertionScenario = scenario("UnknownAssertion", null, ({ te
                 const values = unknownAssertionGenerators.toBeObject.invalid();
 
                 for (const value of values) {
-                    assert.unknown(value).not.toBeObject();
+                    expect.unknown(value).not.toBeObject();
                 }
             });
         });
@@ -134,7 +134,7 @@ export const UnknownAssertionScenario = scenario("UnknownAssertion", null, ({ te
                 const values = unknownAssertionGenerators.toBeArray.valid();
 
                 for (const value of values) {
-                    assert.unknown(value).toBeArray();
+                    expect.unknown(value).toBeArray();
                 }
             });
 
@@ -142,7 +142,7 @@ export const UnknownAssertionScenario = scenario("UnknownAssertion", null, ({ te
                 const values = unknownAssertionGenerators.toBeArray.invalid();
 
                 for (const value of values) {
-                    assert.unknown(value).not.toBeArray();
+                    expect.unknown(value).not.toBeArray();
                 }
             });
         });
@@ -152,7 +152,7 @@ export const UnknownAssertionScenario = scenario("UnknownAssertion", null, ({ te
                 const values = unknownAssertionGenerators.toBeInstanceOf.valid();
 
                 for (const { value, className } of values) {
-                    assert.unknown(value).toBeInstanceOf(className);
+                    expect.unknown(value).toBeInstanceOf(className);
                 }
             });
 
@@ -165,7 +165,7 @@ export const UnknownAssertionScenario = scenario("UnknownAssertion", null, ({ te
                             continue;
                         }
 
-                        assert.unknown(value).not.toBeInstanceOf(className);
+                        expect.unknown(value).not.toBeInstanceOf(className);
                     }
                 }
             });

--- a/tests/behaviour/reporting/scenario.ts
+++ b/tests/behaviour/reporting/scenario.ts
@@ -1,30 +1,30 @@
-import { assert, scenario } from "src";
+import { expect, scenario } from "src";
 
 export const ReportingScenario = scenario("Reporting scenario", null, ({ test }) => {
     test.parallel("Parallel root group", ({ test }) => {
         test.serial("Serial group (should succeed)", ({ test }) => {
             test.sample("should succeed", () => {
-                assert.number(1).toBe(1);
+                expect.number(1).toBe(1);
             });
         });
 
         test.serial("Serial group (should fail)", ({ test }) => {
             test.sample("should succeed", () => {
-                assert.number(1).toBe(1);
+                expect.number(1).toBe(1);
             });
 
             test.sample("should fail", () => {
-                assert.number(1).toBe(2);
+                expect.number(1).toBe(2);
             });
 
             test.sample("should not run", () => {
-                assert.number(1).toBe(1);
+                expect.number(1).toBe(1);
             });
         });
 
         test.serial("Serial group (should fail with error)", ({ test }) => {
             test.sample("should succeed", () => {
-                assert.number(1).toBe(1);
+                expect.number(1).toBe(1);
             });
 
             test.sample("should throw error", () => {
@@ -32,39 +32,39 @@ export const ReportingScenario = scenario("Reporting scenario", null, ({ test })
             });
 
             test.sample("should not run", () => {
-                assert.number(1).toBe(1);
+                expect.number(1).toBe(1);
             });
         });
 
         test.parallel("Parallel group (should succeed)", ({ test }) => {
             test.sample("should succeed", () => {
-                assert.number(1).toBe(1);
+                expect.number(1).toBe(1);
             });
         });
 
         test.parallel("Parallel group (one child should fail)", ({ test }) => {
             test.sample("should succeed", () => {
-                assert.number(1).toBe(1);
+                expect.number(1).toBe(1);
             });
 
             test.sample("should fail", () => {
-                assert.number(1).toBe(2);
+                expect.number(1).toBe(2);
             });
 
             test.sample("should not run", () => {
-                assert.number(1).toBe(1);
+                expect.number(1).toBe(1);
             });
 
             test.serial("Serial group (should not run)", ({ test }) => {
                 test.sample("should not run", () => {
-                    assert.number(1).toBe(1);
+                    expect.number(1).toBe(1);
                 });
             });
         });
 
         test.parallel("Parallel group (one child should fail with error)", ({ test }) => {
             test.sample("should succeed", () => {
-                assert.number(1).toBe(1);
+                expect.number(1).toBe(1);
             });
 
             test.sample("should fail", () => {
@@ -72,12 +72,12 @@ export const ReportingScenario = scenario("Reporting scenario", null, ({ test })
             });
 
             test.sample("should not run", () => {
-                assert.number(1).toBe(1);
+                expect.number(1).toBe(1);
             });
 
             test.serial("Serial group (should not run)", ({ test }) => {
                 test.sample("should not run", () => {
-                    assert.number(1).toBe(1);
+                    expect.number(1).toBe(1);
                 });
             });
         });

--- a/tests/behaviour/reusable-tests/scenario.ts
+++ b/tests/behaviour/reusable-tests/scenario.ts
@@ -1,4 +1,4 @@
-import { assert, reuseTest, scenario } from "src";
+import { expect, reuseTest, scenario } from "src";
 import { NEW_NAME, OLD_NAME } from "./constants";
 import { ChangeNameTest } from "./reusable-test";
 
@@ -10,13 +10,13 @@ const scenarioState = {
 export const ReusableTestsScenario = scenario("Reusable tests", scenarioState, ({ test }) => {
     test.serial("Serial root group", ({ test }) => {
         test.sample("check name before changing", ({ state }) => {
-            assert.string(state.name).toBe(OLD_NAME);
+            expect.string(state.name).toBe(OLD_NAME);
         });
 
         reuseTest("should change state name", test, ChangeNameTest);
 
         test.sample("check name after changing", ({ state }) => {
-            assert.string(state.name).toBe(NEW_NAME);
+            expect.string(state.name).toBe(NEW_NAME);
         });
     });
 });

--- a/tests/behaviour/state/scenario.ts
+++ b/tests/behaviour/state/scenario.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker/.";
-import { scenario, assert } from "src";
+import { scenario, expect } from "src";
 
 const scenarioState = {
     value: 0
@@ -12,7 +12,7 @@ export const StateManagementScenario = scenario("State management", scenarioStat
         for (let i = 0; i < values.length; i++) {
             test.sample(`Set value to ${values[i]}`, ({ state }) => {
                 if (i !== 0) {
-                    assert.number(state.value).toBe(values[i - 1]);
+                    expect.number(state.value).toBe(values[i - 1]);
                 }
 
                 state.value = values[i];


### PR DESCRIPTION
Rename `assert` constant into `expect`

## PR Type

- [ ] Feature
- [x] Bugfix
- [ ] Testing
- [x] Refactoring (no functional changes, no api changes)
- [ ] Chore (project setup, etc.)
- [ ] Documentation
- [ ] Performance optimization
- [ ] Build related changes
- [ ] CI related changes

---

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

**BREAKING CHANGE**: Use `expect` constant instead of `assert`.