### PR TITLE
Fix/test skipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
     - [Sample](#sample)
   - [Lifecycle Hooks](#lifecycle-hooks)
   - [Reusable Tests](#reusable-tests)
-  - [Skiping Tests](#skiping-tests)
+  - [Skipping Tests](#skipping-tests)
   - [Reporting](#reporting)
 - [Assertions](#assertions)
   - [Basic Assertions](#basic-assertions)
@@ -376,26 +376,26 @@ _The type of test being reused should be a supertype of the scenario state type.
 
 This condition is necessary for type safety.
 
-### Skiping Tests 
+### Skipping Tests 
 
 Grinch provides the ability to skip tests, groups, and hooks. You can easily replace the names of missing methods with the methods you need. Methods for skipping tests:
 
 Example:
 
 ```typescript
-// skiping sample test execution
+// skipping sample test execution
 test.skip.sample(/* ... */);
 
-// skiping group execution (children tests will not be executed)
+// skipping group execution (children tests will not be executed)
 test.skip.serial(/* ... */);
 test.skip.parallel(/* ... */);
 
-// skiping hooks execution
+// skipping hooks execution
 test.skip.beforeEach(/* ... */);
 test.skip.afterEach(/* ... */);
 ```
 
-**Note**: _If you are skiping tests group execution (`serial` or `parallel`) all children tests will also be skiped_.
+**Note**: _If you are skipping tests group execution (`serial` or `parallel`) all children tests will also be skipped_.
 
 ### Reporting
 

--- a/README.md
+++ b/README.md
@@ -14,15 +14,16 @@
 - [Philosophy](#philosophy)
 - [Installation](#installation)
 - [Basic Usage](#basic-usage)
-- [Test Types](#test-types)
-  - [Scenario](#scenario)
-  - [Parallel](#parallel)
-  - [Serial](#serial)
-  - [Sample](#sample)
-- [Lifecycle Hooks](#lifecycle-hooks)
-- [Reusable Tests](#reusable-tests)
-- [Tests Skiping](#tests-skiping)
-- [Reporting](#reporting)
+- [Features](#features)
+  - [Grouping Tests](#grouping-tests)
+    - [Scenario](#scenario)
+    - [Parallel](#parallel)
+    - [Serial](#serial)
+    - [Sample](#sample)
+  - [Lifecycle Hooks](#lifecycle-hooks)
+  - [Reusable Tests](#reusable-tests)
+  - [Skiping Tests](#skiping-tests)
+  - [Reporting](#reporting)
 - [Assertions](#assertions)
   - [Basic Assertions](#basic-assertions)
   - [Iterable Values Assertions](#iterable-values-assertions)
@@ -194,13 +195,17 @@ npx ts-node your-file.ts posts
 
 Grinch will search for command provided in CLI and run corresponding scenarios in parallel.
 
-## Test Types
+
+
+## Features
+
+### Grouping Tests
 
 When writing tests, Grinch saves them as a tree object, allowing you to group certain logic.
 
 You can combine different ways to group tests.
 
-### Scenario
+#### Scenario
 
 Scenario is a specific sequence of actions, allowing you to simulate the actions of a real user.
 
@@ -222,7 +227,7 @@ const SomeScenario = scenario("Scenario title", state, ({ test }) => {
 
 It is assumed that the scenario contains within itself one root test, which is the parent for many other tests. If you declare several tests at the root of the scenario, they will all be executed **sequentially**.
 
-### Parallel
+#### Parallel
 
 All tests declared in the root of the parallel test will be executed in parallel.
 
@@ -238,7 +243,7 @@ test.parallel("TestInfo title", ({ test }) => {
 
 **Note**: _It is very dangerous to change the general state of the scenario in parallel tests. Be careful with this_.
 
-### Serial
+#### Serial
 
 All tests declared in the root of the serial test will be executed sequentially.
 
@@ -252,7 +257,7 @@ test.serial("TestInfo title", ({ test }) => {
 // ...
 ```
 
-### Sample
+#### Sample
 
 Sample test represents the leaf element of the scenario test tree. It can access the scenario state and perform various testing logic of your application.
 
@@ -266,7 +271,7 @@ test.sample("TestInfo title", async ({ state }) => {
 // ...
 ```
 
-## Lifecycle Hooks
+### Lifecycle Hooks
 
 Grinch provides the ability to create `beforeEach` and `afterEach` hooks.
 
@@ -304,7 +309,7 @@ test.serial("TestInfo title", ({ test }) => {
 
 In the example above, the test is the first in the sequence. Therefore, the behavior of this test will be similar to the behavior of the `beforeAll` hook. The `afterAll` hook can be implemented in a similar way.
 
-## Reusable Tests
+### Reusable Tests
 
 One of the key features of Grinch is reusable tests. This feature can greatly reduce the number of duplicates in the code.
 
@@ -371,19 +376,28 @@ _The type of test being reused should be a supertype of the scenario state type.
 
 This condition is necessary for type safety.
 
-## Tests Skiping
+### Skiping Tests 
 
 Grinch provides the ability to skip tests, groups, and hooks. You can easily replace the names of missing methods with the methods you need. Methods for skipping tests:
 
-| Method      | Associations              | Description                                                        |
-| ----------- | ------------------------- | ------------------------------------------------------------------ |
-| `skip`      | `sample`                  | Skip sample test                                                   |
-| `skipGroup` | `serial`, `parallel`      | Skip test group. All children tests and hooks will not be executed |
-| `skipHook`  | `beforeEach`, `afterEach` | Skip lifecycle hook                                                |
+Example:
 
-You may notice that the `skip` and `skipHook` methods can be used interchangeably. This duplication is done for greater clarity in the code.
+```typescript
+// skiping sample test execution
+test.skip.sample(/* ... */);
 
-## Reporting
+// skiping group execution (children tests will not be executed)
+test.skip.serial(/* ... */);
+test.skip.parallel(/* ... */);
+
+// skiping hooks execution
+test.skip.beforeEach(/* ... */);
+test.skip.afterEach(/* ... */);
+```
+
+**Note**: _If you are skiping tests group execution (`serial` or `parallel`) all children tests will also be skiped_.
+
+### Reporting
 
 Сalling the `mapScenarios` function returns an array of objects of type:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export { createScenario as scenario, mapScenarios } from "@modules/scenarios";
 export { createReusableTest as reusableTest, reuseTest } from "@modules/reusable-tests";
 export { type Results } from "@modules/testing-tree";
 export { expect } from "@modules/assertions";
+

--- a/src/modules/tests/model/base-test-factory.ts
+++ b/src/modules/tests/model/base-test-factory.ts
@@ -18,7 +18,7 @@ export abstract class BaseTestFactory<State> {
      * @param _callback The callback function that defines the logic of the sample test. It receives the current state.
      * @returns void
      */
-    public abstract skip(_title: string, _callback: SampleTestCallback<State>): void;
+    //public abstract skip(_title: string, _callback: SampleTestCallback<State>): void;
 
     /**
      * Creates a tests group in which all children tests will be executed one after another.
@@ -39,15 +39,6 @@ export abstract class BaseTestFactory<State> {
     public abstract parallel(title: string, callback: TestGroupCallback<State>): void;
 
     /**
-     * Creates a tests group within the current test factory. This tests group will not be executed.
-     *
-     * @param title The title of the parallel test.
-     * @param callback The callback function that defines the logic of the parallel test. It receives the current state.
-     * @returns void
-     */
-    public abstract skipGroup(_title: string, _callback: TestGroupCallback<State>): void;
-
-    /**
      * Registers a hook that runs before each test in the current group.
      *
      * @param _callback The callback function to be executed. It receives the current state.
@@ -62,14 +53,6 @@ export abstract class BaseTestFactory<State> {
      * @returns void
      */
     public abstract afterEach(callback: LifecycleHookCallback<State>): void;
-
-    /**
-     * A no-op function that can be used to skip a lifecycle hook.
-     *
-     * @param _callback The callback function to be skipped.
-     * @returns void
-     */
-    public abstract skipHook(_callback: LifecycleHookCallback<State>): void;
 
     // ! Necessarily Check
     // public reuse<ReusableState>(

--- a/src/modules/tests/model/skip-test-factory.ts
+++ b/src/modules/tests/model/skip-test-factory.ts
@@ -6,9 +6,6 @@ export class SkipTestFactory<State> extends BaseTestFactory<State> {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public sample(_title: string, _callback: SampleTestCallback<State>) {}
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public skip(_title: string, _callback: SampleTestCallback<State>) {}
-
     public serial(_title: string, callback: TestGroupCallback<State>) {
         callback({ test: this });
     }
@@ -17,16 +14,9 @@ export class SkipTestFactory<State> extends BaseTestFactory<State> {
         callback({ test: this });
     }
 
-    public skipGroup(_title: string, callback: TestGroupCallback<State>) {
-        callback({ test: this });
-    }
-
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public beforeEach(_callback: LifecycleHookCallback<State>) {}
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public afterEach(_callback: LifecycleHookCallback<State>) {}
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public skipHook(_callback: LifecycleHookCallback<State>) {}
 }

--- a/src/modules/tests/model/test-factory.ts
+++ b/src/modules/tests/model/test-factory.ts
@@ -15,6 +15,10 @@ export class TestFactory<State> extends BaseTestFactory<State> {
         super();
     }
 
+    public get skip() {
+        return new SkipTestFactory();
+    }
+
     public sample(title: string, callback: SampleTestCallback<State>) {
         const payload = {
             state: this.state,
@@ -25,9 +29,6 @@ export class TestFactory<State> extends BaseTestFactory<State> {
 
         this.testsStore.addLeaf(test);
     }
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public skip(_title: string, _callback: SampleTestCallback<State>) {}
 
     public serial(title: string, callback: TestGroupCallback<State>) {
         const test = new TestGroup(title);
@@ -49,10 +50,6 @@ export class TestFactory<State> extends BaseTestFactory<State> {
         callback({ test: testFactory });
     }
 
-    public skipGroup(_title: string, callback: TestGroupCallback<State>) {
-        callback({ test: new SkipTestFactory() });
-    }
-
     public beforeEach(callback: LifecycleHookCallback<State>) {
         this.testsStore.hooks.beforeEach.push(() =>
             callback({
@@ -70,9 +67,6 @@ export class TestFactory<State> extends BaseTestFactory<State> {
             })
         );
     }
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public skipHook(_callback: LifecycleHookCallback<State>) {}
 
     // ! Necessarily Check
     // public reuse<ReusableState>(


### PR DESCRIPTION
Fix skipping tests invocation pattern.

## PR Type

- [ ] Feature
- [x] Bugfix
- [ ] Testing
- [x] Refactoring (no functional changes, no api changes)
- [ ] Chore (project setup, etc.)
- [ ] Documentation
- [ ] Performance optimization
- [ ] Build related changes
- [ ] CI related changes

---

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

**BREAKING CHANGE**: Fix skipping tests invocation pattern.

To migrate the code follow the example below:

Before:

```typescript
// skip sample tets
test.skip(/**/);

// skip tests group
test.skipGroup(/**/);

// skip hook
test.skipHook(/**/);
```

After:

```typescript
// skip sample test
test.skip.sample(/**/);

// skip tests group
test.skip.serial(/**/);
test.skip.parallel(/**/);

// skip hook
test.skip.beforeEach(/**/);
test.skip.afterEach(/**/);
```