### PR TITLE
Fix/reusable tests interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,23 +15,23 @@
 - [Installation](#installation)
 - [Basic Usage](#basic-usage)
 - [Features](#features)
-  - [Grouping Tests](#grouping-tests)
-    - [Scenario](#scenario)
-    - [Parallel](#parallel)
-    - [Serial](#serial)
-    - [Sample](#sample)
-  - [Lifecycle Hooks](#lifecycle-hooks)
-  - [Reusable Tests](#reusable-tests)
-  - [Skipping Tests](#skipping-tests)
-  - [Reporting](#reporting)
+    - [Grouping Tests](#grouping-tests)
+        - [Scenario](#scenario)
+        - [Parallel](#parallel)
+        - [Serial](#serial)
+        - [Sample](#sample)
+    - [Lifecycle Hooks](#lifecycle-hooks)
+    - [Reusable Tests](#reusable-tests)
+    - [Skipping Tests](#skipping-tests)
+    - [Reporting](#reporting)
 - [Assertions](#assertions)
-  - [Basic Assertions](#basic-assertions)
-  - [Iterable Values Assertions](#iterable-values-assertions)
-  - [Number Assertions](#number-assertions)
-  - [String Assertions](#string-assertions)
-  - [Record Assertions](#record-assertions)
-  - [Array Assertions](#array-assertions)
-  - [Unknown Assertions](#unknown-assertions)
+    - [Basic Assertions](#basic-assertions)
+    - [Iterable Values Assertions](#iterable-values-assertions)
+    - [Number Assertions](#number-assertions)
+    - [String Assertions](#string-assertions)
+    - [Record Assertions](#record-assertions)
+    - [Array Assertions](#array-assertions)
+    - [Unknown Assertions](#unknown-assertions)
 
 ## Philosophy
 
@@ -195,8 +195,6 @@ npx ts-node your-file.ts posts
 
 Grinch will search for command provided in CLI and run corresponding scenarios in parallel.
 
-
-
 ## Features
 
 ### Grouping Tests
@@ -340,7 +338,7 @@ type PartialState = {
     country: string;
 };
 
-const editCountryTest = reusableTest<PartialState>(({ test }) => {
+const EditCountryTest = reusableTest<PartialState>(({ test }) => {
     test.sample("Edit country", ({ state }) => {
         state.country = "UK";
     });
@@ -361,7 +359,7 @@ type ScenarioState = {
 scenario("Scenario title", state, ({ test }) => {
     test.serial("TestInfo title", ({ test }) => {
         // Here we are reusing editContryTest
-        reuseTest("Edit country", test, editCountryTest);
+        EditCountryTest.use("Edit country", test);
     });
 });
 ```
@@ -376,7 +374,7 @@ _The type of test being reused should be a supertype of the scenario state type.
 
 This condition is necessary for type safety.
 
-### Skipping Tests 
+### Skipping Tests
 
 Grinch provides the ability to skip tests, groups, and hooks. You can easily replace the names of missing methods with the methods you need. Methods for skipping tests:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 export { createScenario as scenario, mapScenarios } from "@modules/scenarios";
-export { createReusableTest as reusableTest, reuseTest } from "@modules/reusable-tests";
+export { createReusableTest as reusableTest } from "@modules/reusable-tests";
 export { type Results } from "@modules/testing-tree";
 export { expect } from "@modules/assertions";
-

--- a/src/modules/reusable-tests/index.ts
+++ b/src/modules/reusable-tests/index.ts
@@ -1,1 +1,1 @@
-export { createReusableTest, reuseTest } from "./utils";
+export { createReusableTest } from "./utils";

--- a/src/modules/reusable-tests/reusable-test.ts
+++ b/src/modules/reusable-tests/reusable-test.ts
@@ -1,0 +1,17 @@
+import { BaseTestFactory } from "@modules/tests";
+import { ReusableTestCallback } from "./types";
+
+export class ReusableTest<State> {
+    public constructor(private readonly callback: ReusableTestCallback<State>) {}
+
+    /**
+     * Reuses a test defined by a `reusableTest` within a test factory.
+     *
+     * @param title The title of the reused test.
+     * @param factory The test factory where the test is being reused.
+     * @param callback The callback that defines the test.
+     */
+    public use<ScenarioState extends State>(title: string, factory: BaseTestFactory<ScenarioState>) {
+        factory.serial(title, this.callback);
+    }
+}

--- a/src/modules/reusable-tests/utils.ts
+++ b/src/modules/reusable-tests/utils.ts
@@ -1,5 +1,6 @@
-import { AvailableTestStates, BaseTestFactory } from "@modules/tests";
+import { AvailableTestStates } from "@modules/tests";
 import { ReusableTestCallback } from "./types";
+import { ReusableTest } from "./reusable-test";
 
 /**
  * Creates a new test instance with the provided test logic callback.
@@ -8,20 +9,5 @@ import { ReusableTestCallback } from "./types";
  * @returns A new reusable test callback.
  */
 export function createReusableTest<State extends AvailableTestStates>(callback: ReusableTestCallback<State>) {
-    return callback;
-}
-
-/**
- * Reuses a test defined by a `reusableTest` within a test factory.
- *
- * @param title The title of the reused test.
- * @param factory The test factory where the test is being reused.
- * @param callback The callback that defines the test.
- */
-export function reuseTest<State extends ReusableState, ReusableState>(
-    title: string,
-    factory: BaseTestFactory<State>,
-    callback: ReusableTestCallback<ReusableState>
-) {
-    factory.serial(title, callback);
+    return new ReusableTest(callback);
 }


### PR DESCRIPTION
Change reusable tests api.

## PR Type

- [x] Feature
- [ ] Bugfix
- [ ] Testing
- [x] Refactoring (no functional changes, no api changes)
- [ ] Chore (project setup, etc.)
- [ ] Documentation
- [ ] Performance optimization
- [ ] Build related changes
- [ ] CI related changes

---

## The change includes:

- replace `reuseTest` function with `ReusableTest` class

---

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, describe the impact and migration path for existing applications below. -->

**BREAKING CHANGE**

Before:

```typescript
reuseTest("Title", testFactory, ReusableTest);
```

After:

```typescript
Reusabletest.use("Title", testFactory);
```