### PR TITLE
fix: add error message functions for expectations

### DIFF
--- a/src/core/expectations/classes/base-expectation.ts
+++ b/src/core/expectations/classes/base-expectation.ts
@@ -27,7 +27,7 @@ export class BaseExpectation<T> {
         return this;
     }
 
-    protected runCondition(condition: Condition, errorMessage: string) {
+    protected runCondition(condition: Condition, errorMessage: string | (() => string)) {
         let conditionToExecute = condition;
 
         if (this.inverseNextCondition) {
@@ -37,7 +37,8 @@ export class BaseExpectation<T> {
 
         const result = conditionToExecute();
         if (!result) {
-            throw new ExpectationError(errorMessage);
+            const message = typeof errorMessage === "function" ? errorMessage() : errorMessage;
+            throw new ExpectationError(message);
         }
     }
 
@@ -50,7 +51,7 @@ export class BaseExpectation<T> {
     public toBe(value: T): this {
         this.runCondition(
             () => this.value === value,
-            `Values are not equal. Expect: ${JSON.stringify(value)}, but receive: ${JSON.stringify(this.value)}`
+            () => `Values are not equal. Expect: ${JSON.stringify(value)}, but receive: ${JSON.stringify(this.value)}`
         );
         return this;
     }
@@ -71,7 +72,10 @@ export class BaseExpectation<T> {
      * @returns The current instance for chaining.
      */
     public toBeNull(): this {
-        this.runCondition(() => this.value === null, `Value is not null. Receive: ${JSON.stringify(this.value)}`);
+        this.runCondition(
+            () => this.value === null,
+            () => `Value is not null. Receive: ${JSON.stringify(this.value)}`
+        );
         return this;
     }
 
@@ -83,7 +87,7 @@ export class BaseExpectation<T> {
     public toBeEmpty(): this {
         this.runCondition(
             () => this.value === null || this.value === undefined,
-            `Value is not empty. Receive: ${JSON.stringify(this.value)}`
+            () => `Value is not empty. Receive: ${JSON.stringify(this.value)}`
         );
         return this;
     }
@@ -96,7 +100,7 @@ export class BaseExpectation<T> {
     public toBeTruthy(): this {
         this.runCondition(
             () => !FALSY_VALUES.includes(this.value as null),
-            `Value is not truthy. Receive: ${JSON.stringify(this.value)}`
+            () => `Value is not truthy. Receive: ${JSON.stringify(this.value)}`
         );
         return this;
     }
@@ -109,7 +113,7 @@ export class BaseExpectation<T> {
     public toBeFalsy(): this {
         this.runCondition(
             () => FALSY_VALUES.includes(this.value as null),
-            `Value is not falsy. Receive: ${JSON.stringify(this.value)}`
+            () => `Value is not falsy. Receive: ${JSON.stringify(this.value)}`
         );
         return this;
     }
@@ -123,7 +127,7 @@ export class BaseExpectation<T> {
     public toBeIn(values: T[]): this {
         this.runCondition(
             () => values.includes(this.value),
-            `Value is not in array. Receive: ${JSON.stringify(this.value)} `
+            () => `Value is not in array. Receive: ${JSON.stringify(this.value)} `
         );
         return this;
     }
@@ -135,7 +139,7 @@ export class BaseExpectation<T> {
      * @returns The current instance for chaining.
      */
     public toMatchZodSchema(schema: ZodSchema): this {
-        this.runCondition(() => schema.safeParse(this.value).success, "Value don't ,atch schema");
+        this.runCondition(() => schema.safeParse(this.value).success, "Value don't ,match schema");
         return this;
     }
 

--- a/src/core/expectations/classes/iterable-expectation.ts
+++ b/src/core/expectations/classes/iterable-expectation.ts
@@ -98,7 +98,10 @@ export class IterableExpectation<T extends string | unknown[]> extends BaseExpec
      * @returns The current instance for chaining.
      */
     public toIncludes(item: T extends string ? string : ElementType<T>): this {
-        this.runCondition(() => this.value.includes(item as string), `Value don't include ${JSON.stringify(item)}`);
+        this.runCondition(
+            () => this.value.includes(item as string),
+            () => `Value don't include ${JSON.stringify(item)}`
+        );
         return this;
     }
 
@@ -112,7 +115,8 @@ export class IterableExpectation<T extends string | unknown[]> extends BaseExpec
     public toHaveValueAtIndex(index: number, item: T extends string ? string : ElementType<T>): this {
         this.runCondition(
             () => this.value[index] === item,
-            `Value don't have such value at index ${index}. Expect: ${JSON.stringify(item)}, but receive: ${JSON.stringify(this.value[index])}`
+            () =>
+                `Value don't have such value at index ${index}. Expect: ${JSON.stringify(item)}, but receive: ${JSON.stringify(this.value[index])}`
         );
         return this;
     }

--- a/src/core/expectations/classes/record-expectation.ts
+++ b/src/core/expectations/classes/record-expectation.ts
@@ -15,7 +15,7 @@ export class RecordExpectation extends BaseExpectation<Record<string, unknown>> 
     public toEquals(value: unknown): this {
         this.runCondition(
             () => deepCompare(this.value, value),
-            `Values are not equal. Expect: ${JSON.stringify(value)}, but receive: ${JSON.stringify(this.value)}`
+            () => `Values are not equal. Expect: ${JSON.stringify(value)}, but receive: ${JSON.stringify(this.value)}`
         );
         return this;
     }
@@ -27,7 +27,10 @@ export class RecordExpectation extends BaseExpectation<Record<string, unknown>> 
      * @returns The current instance for chaining.
      */
     public toHaveKey(key: string): this {
-        this.runCondition(() => !!this.value[key], `Value don't have key '${key}'`);
+        this.runCondition(
+            () => !!this.value[key],
+            () => `Value don't have key '${key}'`
+        );
         return this;
     }
 
@@ -67,7 +70,7 @@ export class RecordExpectation extends BaseExpectation<Record<string, unknown>> 
                 }
                 return deepCompare(this.value[key], value);
             },
-            `Value don't have key '${key}' with value '${JSON.stringify(value)}'`
+            () => `Value don't have key '${key}' with value '${JSON.stringify(value)}'`
         );
         return this;
     }

--- a/src/core/expectations/classes/string-expectation.ts
+++ b/src/core/expectations/classes/string-expectation.ts
@@ -15,7 +15,7 @@ export class StringExpectation extends IterableExpectation<string> {
     public toBeUpperCase(): this {
         this.runCondition(
             () => this.value === this.value.toUpperCase(),
-            `Value is not upper case string. Receive: ${this.value}`
+            `Value is not upper case string. Receive: "${this.value}"`
         );
         return this;
     }
@@ -28,7 +28,7 @@ export class StringExpectation extends IterableExpectation<string> {
     public toBeLowerCase(): this {
         this.runCondition(
             () => this.value === this.value.toLowerCase(),
-            `Value is not lower case string. Receive: ${this.value}`
+            `Value is not lower case string. Receive: "${this.value}"`
         );
         return this;
     }
@@ -42,7 +42,7 @@ export class StringExpectation extends IterableExpectation<string> {
     public toStartsWith(value: string): this {
         this.runCondition(
             () => this.value.startsWith(value),
-            `Value is not starts with ${value}. Receive: ${this.value}`
+            `Value is not starts with "${value}". Receive: "${this.value}"`
         );
         return this;
     }
@@ -54,7 +54,10 @@ export class StringExpectation extends IterableExpectation<string> {
      * @returns The current instance for chaining.
      */
     public toEndsWith(value: string): this {
-        this.runCondition(() => this.value.endsWith(value), `Value is not ends with ${value}. Receive: ${this.value}`);
+        this.runCondition(
+            () => this.value.endsWith(value),
+            `Value is not ends with "${value}". Receive: "${this.value}"`
+        );
         return this;
     }
 
@@ -75,7 +78,7 @@ export class StringExpectation extends IterableExpectation<string> {
     public toBeBooleanString(): this {
         this.runCondition(
             () => this.value === "true" || this.value === "false",
-            `Value is not boolean string. Receive: ${this.value}`
+            `Value is not boolean string. Receive: "${this.value}"`
         );
         return this;
     }
@@ -87,7 +90,10 @@ export class StringExpectation extends IterableExpectation<string> {
      * @returns The current instance for chaining.
      */
     public toMatchRegex(regexp: RegExp): this {
-        this.runCondition(() => regexp.test(this.value), `Value is not match regex ${regexp}. Receive: ${this.value}`);
+        this.runCondition(
+            () => regexp.test(this.value),
+            () => `Value is not match regex /${regexp.source}/${regexp.flags}. Receive: ${this.value}`
+        );
         return this;
     }
 

--- a/src/core/expectations/classes/unknown-expectation.ts
+++ b/src/core/expectations/classes/unknown-expectation.ts
@@ -16,7 +16,7 @@ export class UnknownExpectation extends BaseExpectation<unknown> {
     public toEquals(value: unknown): this {
         this.runCondition(
             () => deepCompare(this.value, value),
-            `Values are not equal. Expect: ${JSON.stringify(value)}, but receive: ${JSON.stringify(this.value)}`
+            () => `Values are not equal. Expect: ${JSON.stringify(value)}, but receive: ${JSON.stringify(this.value)}`
         );
         return this;
     }
@@ -24,7 +24,7 @@ export class UnknownExpectation extends BaseExpectation<unknown> {
     private checkType(type: TypeofResponse): this {
         this.runCondition(
             () => typeof this.value === type,
-            `Value is not of type ${type}. Receive: ${JSON.stringify(this.value)}`
+            () => `Value is not of type ${type}. Receive: ${JSON.stringify(this.value)}`
         );
         return this;
     }
@@ -53,7 +53,10 @@ export class UnknownExpectation extends BaseExpectation<unknown> {
      * @returns The current instance for chaining.
      */
     public toBeNaN(): this {
-        this.runCondition(() => this.value !== this.value, `Value is not NaN. Receive: ${JSON.stringify(this.value)}`);
+        this.runCondition(
+            () => this.value !== this.value,
+            () => `Value is not NaN. Receive: ${JSON.stringify(this.value)}`
+        );
         return this;
     }
 
@@ -89,7 +92,7 @@ export class UnknownExpectation extends BaseExpectation<unknown> {
 
                 return typeof this.value === "object";
             },
-            `Value is not record. Receive: ${JSON.stringify(this.value)}`
+            () => `Value is not record. Receive: ${JSON.stringify(this.value)}`
         );
         return this;
     }
@@ -102,7 +105,7 @@ export class UnknownExpectation extends BaseExpectation<unknown> {
     public toBeArray(): this {
         this.runCondition(
             () => Array.isArray(this.value),
-            `Value is not array. Receive: ${JSON.stringify(this.value)}`
+            () => `Value is not array. Receive: ${JSON.stringify(this.value)}`
         );
         return this;
     }


### PR DESCRIPTION
Refactor `BaseExpectation.runCondition` method.

## PR Type

- [ ] Feature
- [ ] Bugfix
- [ ] Testing
- [x] Refactoring (no functional changes, no api changes)
- [ ] Chore (project setup, etc.)
- [ ] Documentation
- [x] Performance optimization
- [ ] Build related changes
- [ ] CI related changes

---

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

**BREAKING CHANGE**: `BaseExpectation.runCondition` method changed.

Before:

```typescript
public runCondition(condition: Condition, errorMessage: string) {
    // ...
}
```

After:

```typescript
public runCondition(condition: Condition, errorMessage: string | (() => string)) {
    // ...
}
```